### PR TITLE
fix colab linking

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -43,6 +43,19 @@ jobs:
           pwd
           ls
           conda list
+
+      - name: set dev path
+        run: |
+          echo "PAGES_DEPLOY_PATH=dev" >> $GITHUB_ENV
+        if: github.event_name == 'push'
+      - name: set PR path
+        run: |
+          echo "PAGES_DEPLOY_PATH=PR${{ github.event.number }}" >> $GITHUB_ENV
+        if: github.event_name == 'pull_request'
+      - name: set release path
+        run: |
+         echo "PAGES_DEPLOY_PATH=${GITHUB_REF}" >> $GITHUB_ENV
+        if: github.event_name == 'release'
       - name: Build Sphinx documentation
         run: |
           make html
@@ -74,9 +87,10 @@ jobs:
           PR: ${{ github.event.number }}
         run: |
           rm -rf deploy/${GITHUB_REF}
-          mv build/html deploy/${GITHUB_REF}
-          rm deploy/latest
-          ln -s deploy/${GITHUB_REF} deploy/latest
+          mkdir -p deploy/${GITHUB_REF}
+          mv -T build/html deploy/${GITHUB_REF}
+          rm -rf deploy/latest
+          ln -s ${GITHUB_REF} deploy/latest
       - name: Deploy to GitHub Pages
         if: success()
         uses: crazy-max/ghaction-github-pages@v2

--- a/conf.py
+++ b/conf.py
@@ -20,6 +20,7 @@ sys.path.insert(0, os.path.abspath("./sphinx"))
 project = "OpenMM Cookbook"
 copyright = "2022, The OpenMM Contributors"
 author = "The OpenMM Contributors"
+releasepath = os.getenv("PAGES_DEPLOY_PATH","dev")
 
 
 # -- General configuration ---------------------------------------------------
@@ -56,11 +57,12 @@ cookbook_required_files_base_uri = (
 
 # Add links to top of each notebook
 nbsphinx_prolog = """
+{%- set releasepath = env.config.releasepath %}
 {%- set docname = env.doc2path(env.docname, base=False) -%}
 {%- set github = "openmm/openmm-cookbook" -%}
 {%- set on_local = docname.split('/') | last -%}
 {%- set on_github = "https://github.com/" ~ github ~ "/blob/main/" ~ docname -%}
-{%- set on_colab = "https://colab.research.google.com/github/" ~ github ~ "/blob/gh-pages/dev/colab/" ~ docname -%}
+{%- set on_colab = "https://colab.research.google.com/github/" ~ github ~ "/blob/gh-pages/" ~ releasepath ~ "/colab/" ~ docname -%}
 .. raw:: html
 
     <div class="nbsphinx-prolog">

--- a/conf.py
+++ b/conf.py
@@ -20,7 +20,8 @@ sys.path.insert(0, os.path.abspath("./sphinx"))
 project = "OpenMM Cookbook"
 copyright = "2022, The OpenMM Contributors"
 author = "The OpenMM Contributors"
-releasepath = os.getenv("PAGES_DEPLOY_PATH","dev")
+release = os.getenv("PAGES_DEPLOY_PATH","dev")
+print(release)
 
 
 # -- General configuration ---------------------------------------------------
@@ -57,12 +58,12 @@ cookbook_required_files_base_uri = (
 
 # Add links to top of each notebook
 nbsphinx_prolog = """
-{%- set releasepath = env.config.releasepath %}
+{%- set colabpath = env.config.release -%}
 {%- set docname = env.doc2path(env.docname, base=False) -%}
 {%- set github = "openmm/openmm-cookbook" -%}
 {%- set on_local = docname.split('/') | last -%}
 {%- set on_github = "https://github.com/" ~ github ~ "/blob/main/" ~ docname -%}
-{%- set on_colab = "https://colab.research.google.com/github/" ~ github ~ "/blob/gh-pages/" ~ releasepath ~ "/colab/" ~ docname -%}
+{%- set on_colab = "https://colab.research.google.com/github/" ~ github ~ "/blob/gh-pages/" ~ colabpath ~ "/colab/" ~ docname -%}
 .. raw:: html
 
     <div class="nbsphinx-prolog">


### PR DESCRIPTION
The open in colab link will open the dev, PR#, or latest release version.
This is done using a environmental variable set during the build workflow and read by conf.py

Added some fixes to the release deployment workflow which I tested on a personal fork: https://sef43.github.io/openmm-cookbook/latest/index.html