### PR TITLE
Add CI test for building the website with sphinx

### DIFF
--- a/.github/workflows/test_website.yml
+++ b/.github/workflows/test_website.yml
@@ -1,0 +1,45 @@
+name: test website
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    types: [opened, edited, synchronize, reopened]
+
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Cache conda
+        uses: actions/cache@v2
+        with:
+          path: ~/conda_pkgs_dir
+          key: ${{ runner.os }}-conda-${{hashFiles('environment.yml') }}
+
+      - uses: conda-incubator/setup-miniconda@v2
+        name: Install dependencies
+        with:
+          environment-file: environment.yml
+          auto-activate-base: false
+          miniforge-version: latest
+          miniforge-variant: Mambaforge
+          use-mamba: true
+
+      - name: Describe environment
+        run: |
+          pwd
+          ls
+          conda list
+
+      - name: Build Sphinx documentation
+        run: |
+          make html
+          

--- a/cookbook.md
+++ b/cookbook.md
@@ -49,7 +49,7 @@ glob: True
 caption: Analysis and System Inspection
 ---
 notebooks/cookbook/Analyzing Energy Contributions
-notebooks/cookbook/Querying Charges and Other Parameters
+notebooks/cookbook/Querying and Modifying Charges and Other Parameters.ipynb
 :::
 
 

--- a/notebooks/cookbook/Querying and Modifying Charges and Other Parameters.ipynb
+++ b/notebooks/cookbook/Querying and Modifying Charges and Other Parameters.ipynb
@@ -12,7 +12,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "9323aaae",
    "metadata": {},
    "outputs": [],
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "1734190f",
    "metadata": {},
    "outputs": [],
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "bf38fc9a",
    "metadata": {},
    "outputs": [],
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "933928f9",
    "metadata": {},
    "outputs": [
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "id": "086c7629",
    "metadata": {},
    "outputs": [],
@@ -140,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "id": "68498ff5",
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
This PR adds a new Github actions workflow "test website" that is run on PRs to main. It will run the sphinx-build process. This test should pass before merging to main. 
Note that unlike the current "website" workflow this one does not try and deploy to github pages. The existing "website" workflow cannot deploy to gh-pages from a personal fork, this hides build errors in the sphinx docs, e.g. this PR failed to build the website: https://github.com/openmm/openmm-cookbook/actions/runs/4855480375

This PR also fixes the error from #18 